### PR TITLE
Draft

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ script:
 - echo {} > credentials.json
 - grunt zip
 - NGROK_PATH=$(curl 'http://localhost:4040/api/tunnels' | ./jq -r '.tunnels[0].public_url')/theme.zip
+- echo ${NGROK_PATH}
 - echo "{\"theme\":{\"name\":\"Travis Curl Test - $(date +"%D %T %Z")\",\"src\":\"$NGROK_PATH\"}}" > body.json
 - echo $(cat body.json)
 - 'TEST_THEME_ID=$(curl -d @body.json -H "Accept: application/json" -H "Content-Type: application/json" https://$SHOPIFY_API_KEY:$SHOPIFY_API_PASSWORD@$SHOPIFY_URL/admin/api/2019-04/themes.json | ./jq -r ''.theme.id'')'

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,12 +20,14 @@ script:
 - echo {} > credentials.json
 - grunt zip
 - NGROK_PATH=$(curl 'http://localhost:4040/api/tunnels' | jq -r '.tunnels[0].public_url')/theme.zip
+- echo ${NGROK_PATH}
 - echo "{\"theme\":{\"name\":\"Travis Curl Test - $(date +"%D %T %Z")\",\"src\":\"$NGROK_PATH\"}}"
   > body.json
 - echo $(cat body.json)
 - 'TEST_THEME_ID=$(curl -d @body.json -H "Accept: application/json" -H "Content-Type:
   application/json" https://${SHOPIFY_API_KEY}:${SHOPIFY_API_PASSWORD}@${SHOPIFY_URL}/admin/api/2019-04/themes.json
   | jq -r ''.theme.id'')'
+- echo ${TEST_THEME_ID}
 - if [ ${TEST_THEME_ID} == null ] ; then exit 1 ; fi
 - while [ $(curl https://${SHOPIFY_API_KEY}:${SHOPIFY_API_PASSWORD}@${SHOPIFY_URL}/admin/api/2019-04/themes/$TEST_THEME_ID.json
   | jq -r '.theme.previewable') != 'true' ]; do echo 'Waiting for theme'; sleep 2;

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,9 +24,7 @@ script:
 - echo "{\"theme\":{\"name\":\"Travis Curl Test - $(date +"%D %T %Z")\",\"src\":\"$NGROK_PATH\"}}"
   > body.json
 - echo $(cat body.json)
-- 'TEST_THEME_ID=$(curl -d @body.json -H "Accept: application/json" -H "Content-Type:
-  application/json" https://${SHOPIFY_API_KEY}:${SHOPIFY_API_PASSWORD}@${SHOPIFY_URL}/admin/api/2019-04/themes.json
-  | jq -r ''.theme.id'')'
+- 'TEST_THEME_ID=$(curl -d @body.json -H "Accept: application/json" -H "Content-Type: application/json" https://$SHOPIFY_API_KEY:$SHOPIFY_API_PASSWORD@$SHOPIFY_URL/admin/api/2019-04/themes.json | ./jq -r ''.theme.id'')'
 - echo ${TEST_THEME_ID}
 - if [ ${TEST_THEME_ID} == null ] ; then exit 1 ; fi
 - while [ $(curl https://${SHOPIFY_API_KEY}:${SHOPIFY_API_PASSWORD}@${SHOPIFY_URL}/admin/api/2019-04/themes/$TEST_THEME_ID.json | jq -r '.theme.previewable') != 'true' ]; do echo 'Waiting for theme'; sleep 2;

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ addons:
     packages:
       # Ubuntu 16+ does not install this dependency by default, so we need to install it ourselves
       - libgconf-2-4
-env:
-  global:
-    # Needs to be amended to get travis to work, could use global variable
-  - SHOPIFY_URL: integration-testing-example.myshopify.com
+# env:
+#   global:
+#     # Needs to be amended to get travis to work, could use global variable
+#   - SHOPIFY_URL: integration-testing-example.myshopify.com

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,33 +7,24 @@ cache:
   directories:
     - /home/travis/.cache/Cypress
     - ~/.npm
-install:
-- npm install
-- npm install -g ngrok
-- npm install -g grunt-cli 
-before_script:
+script:
+- npm i -g ngrok --unsafe-perm=true --allow-root
+- npm install -g grunt-cli
 - mkdir public
 - curl -sO http://stedolan.github.io/jq/download/linux64/jq
-- ngrok http file://$(pwd)/public/ --authtoken=${NGROK_AUTH_TOKEN} > /dev/null &
+- chmod +x jq
+- ngrok http file://$(pwd)/public/ --authtoken=$NGROK_AUTH_TOKEN > /dev/null &
 - sleep 3
-script:
 - echo {} > credentials.json
 - grunt zip
-- NGROK_PATH=$(curl 'http://localhost:4040/api/tunnels' | jq -r '.tunnels[0].public_url')/theme.zip
-- echo ${NGROK_PATH}
-- echo "{\"theme\":{\"name\":\"Travis Curl Test - $(date +"%D %T %Z")\",\"src\":\"$NGROK_PATH\"}}" > body.json
+- NGROK_PATH=$(curl 'http://localhost:4040/api/tunnels' | ./jq -r '.tunnels[0].public_url')/theme.zip
+- echo "{\"theme\":{\"name\":\"GitlabCI Curl Test - $(date +"%D %T %Z")\",\"src\":\"$NGROK_PATH\"}}" > body.json
 - echo $(cat body.json)
-- 'TEST_THEME_ID=$(curl -d @body.json -H "Accept: application/json" -H "Content-Type:
-  application/json" https://${SHOPIFY_API_KEY}:${SHOPIFY_API_PASSWORD}@${SHOPIFY_URL}/admin/api/2019-04/themes.json
-  | jq -r ''.theme.id'')'
+- 'TEST_THEME_ID=$(curl -d @body.json -H "Accept: application/json" -H "Content-Type: application/json" https://$SHOPIFY_API_KEY:$SHOPIFY_API_PASSWORD@$SHOPIFY_URL/admin/api/2019-04/themes.json | ./jq -r ''.theme.id'')'
 - if [ ${TEST_THEME_ID} == null ] ; then exit 1 ; fi
 - while [ $(curl https://$SHOPIFY_API_KEY:$SHOPIFY_API_PASSWORD@$SHOPIFY_URL/admin/api/2019-04/themes/$TEST_THEME_ID.json | ./jq -r '.theme.previewable') != 'true' ]; do echo 'Waiting for theme'; sleep 2; done
-   
-# - while [ $(curl https://${SHOPIFY_API_KEY}:${SHOPIFY_API_PASSWORD}@${SHOPIFY_URL}/admin/api/2019-04/themes/$TEST_THEME_ID.json
-# | jq -r '.theme.previewable') != 'true' ]; do echo 'Waiting for theme'; sleep 2;
-#   done
-- cypress run --env SHOPIFY_URL=${SHOPIFY_URL},SHOPIFY_THEME_ID=$TEST_THEME_ID
-- 'curl -H "Accept: application/json" -X DELETE https://${SHOPIFY_API_KEY}:${SHOPIFY_API_PASSWORD}@${SHOPIFY_URL}/admin/api/2019-04/themes/$TEST_THEME_ID.json'
+- $(npm bin)/cypress run --env SHOPIFY_URL=$SHOPIFY_URL,SHOPIFY_THEME_ID=$TEST_THEME_ID
+- 'curl -H "Accept: application/json" -X DELETE https://$SHOPIFY_API_KEY:$SHOPIFY_API_PASSWORD@$SHOPIFY_URL/admin/api/2019-04/themes/$TEST_THEME_ID.json'
 addons:
   chrome: stable
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,16 +20,17 @@ script:
 - echo {} > credentials.json
 - grunt zip
 - NGROK_PATH=$(curl 'http://localhost:4040/api/tunnels' | jq -r '.tunnels[0].public_url')/theme.zip
-- echo ${NGROK_PATH}
-- echo "{\"theme\":{\"name\":\"Travis Curl Test - $(date +"%D %T %Z")\",\"src\":\"$NGROK_PATH\"}}"
-  > body.json
+- echo "{\"theme\":{\"name\":\"Travis Curl Test - $(date +"%D %T %Z")\",\"src\":\"$NGROK_PATH\"}}" > body.json
 - echo $(cat body.json)
-- 'TEST_THEME_ID=$(curl -d @body.json -H "Accept: application/json" -H "Content-Type: application/json" https://$SHOPIFY_API_KEY:$SHOPIFY_API_PASSWORD@$SHOPIFY_URL/admin/api/2019-04/themes.json | ./jq -r ''.theme.id'')'
-- echo $TEST_THEME_ID
-- echo $SHOPIFY_URL
+- 'TEST_THEME_ID=$(curl -d @body.json -H "Accept: application/json" -H "Content-Type:
+  application/json" https://${SHOPIFY_API_KEY}:${SHOPIFY_API_PASSWORD}@${SHOPIFY_URL}/admin/api/2019-04/themes.json
+  | jq -r ''.theme.id'')'
 - if [ ${TEST_THEME_ID} == null ] ; then exit 1 ; fi
-- while [ $(curl https://${SHOPIFY_API_KEY}:${SHOPIFY_API_PASSWORD}@${SHOPIFY_URL}/admin/api/2019-04/themes/$TEST_THEME_ID.json | jq -r '.theme.previewable') != 'true' ]; do echo 'Waiting for theme'; sleep 2;
-  done
+- while [ $(curl https://$SHOPIFY_API_KEY:$SHOPIFY_API_PASSWORD@$SHOPIFY_URL/admin/api/2019-04/themes/$TEST_THEME_ID.json | ./jq -r '.theme.previewable') != 'true' ]; do echo 'Waiting for theme'; sleep 2; done
+   
+# - while [ $(curl https://${SHOPIFY_API_KEY}:${SHOPIFY_API_PASSWORD}@${SHOPIFY_URL}/admin/api/2019-04/themes/$TEST_THEME_ID.json
+# | jq -r '.theme.previewable') != 'true' ]; do echo 'Waiting for theme'; sleep 2;
+#   done
 - cypress run --env SHOPIFY_URL=${SHOPIFY_URL},SHOPIFY_THEME_ID=$TEST_THEME_ID
 - 'curl -H "Accept: application/json" -X DELETE https://${SHOPIFY_API_KEY}:${SHOPIFY_API_PASSWORD}@${SHOPIFY_URL}/admin/api/2019-04/themes/$TEST_THEME_ID.json'
 addons:
@@ -38,7 +39,6 @@ addons:
     packages:
       # Ubuntu 16+ does not install this dependency by default, so we need to install it ourselves
       - libgconf-2-4
-# env:
-#   global:
-#     # Needs to be amended to get travis to work, could use global variable
-#   - SHOPIFY_URL: integration-testing-example.myshopify.com
+env:
+  global:
+  - SHOPIFY_URL: integration-testing-example.myshopify.com

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ script:
 - echo {} > credentials.json
 - grunt zip
 - NGROK_PATH=$(curl 'http://localhost:4040/api/tunnels' | jq -r '.tunnels[0].public_url')/theme.zip
+- echo ${NGROK_PATH}
 - echo "{\"theme\":{\"name\":\"Travis Curl Test - $(date +"%D %T %Z")\",\"src\":\"$NGROK_PATH\"}}" > body.json
 - echo $(cat body.json)
 - 'TEST_THEME_ID=$(curl -d @body.json -H "Accept: application/json" -H "Content-Type:

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,6 @@ addons:
     packages:
       # Ubuntu 16+ does not install this dependency by default, so we need to install it ourselves
       - libgconf-2-4
-env:
-  global:
-  - SHOPIFY_URL: integration-testing-example.myshopify.com
+# env:
+#   global:
+#   - SHOPIFY_URL: integration-testing-example.myshopify.com

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ cache:
 install:
 - npm install
 - npm install -g ngrok
+- npm install -g grunt-cli 
 before_script:
 - mkdir public
 - curl -sO http://stedolan.github.io/jq/download/linux64/jq

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,8 +29,7 @@ script:
   | jq -r ''.theme.id'')'
 - echo ${TEST_THEME_ID}
 - if [ ${TEST_THEME_ID} == null ] ; then exit 1 ; fi
-- while [ $(curl https://${SHOPIFY_API_KEY}:${SHOPIFY_API_PASSWORD}@${SHOPIFY_URL}/admin/api/2019-04/themes/$TEST_THEME_ID.json
-  | jq -r '.theme.previewable') != 'true' ]; do echo 'Waiting for theme'; sleep 2;
+- while [ $(curl https://${SHOPIFY_API_KEY}:${SHOPIFY_API_PASSWORD}@${SHOPIFY_URL}/admin/api/2019-04/themes/$TEST_THEME_ID.json | jq -r '.theme.previewable') != 'true' ]; do echo 'Waiting for theme'; sleep 2;
   done
 - cypress run --env SHOPIFY_URL=${SHOPIFY_URL},SHOPIFY_THEME_ID=$TEST_THEME_ID
 - 'curl -H "Accept: application/json" -X DELETE https://${SHOPIFY_API_KEY}:${SHOPIFY_API_PASSWORD}@${SHOPIFY_URL}/admin/api/2019-04/themes/$TEST_THEME_ID.json'
@@ -42,4 +41,5 @@ addons:
       - libgconf-2-4
 env:
   global:
+    # Needs to be amended to get travis to work, could use global variable
   - SHOPIFY_URL: integration-testing-example.myshopify.com

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,11 +14,11 @@ script:
 - curl -sO http://stedolan.github.io/jq/download/linux64/jq
 - chmod +x jq
 - ngrok http file://$(pwd)/public/ --authtoken=$NGROK_AUTH_TOKEN > /dev/null &
-- sleep 3
+- sleep 10
 - echo {} > credentials.json
 - grunt zip
 - NGROK_PATH=$(curl 'http://localhost:4040/api/tunnels' | ./jq -r '.tunnels[0].public_url')/theme.zip
-- echo "{\"theme\":{\"name\":\"GitlabCI Curl Test - $(date +"%D %T %Z")\",\"src\":\"$NGROK_PATH\"}}" > body.json
+- echo "{\"theme\":{\"name\":\"Travis Curl Test - $(date +"%D %T %Z")\",\"src\":\"$NGROK_PATH\"}}" > body.json
 - echo $(cat body.json)
 - 'TEST_THEME_ID=$(curl -d @body.json -H "Accept: application/json" -H "Content-Type: application/json" https://$SHOPIFY_API_KEY:$SHOPIFY_API_PASSWORD@$SHOPIFY_URL/admin/api/2019-04/themes.json | ./jq -r ''.theme.id'')'
 - if [ ${TEST_THEME_ID} == null ] ; then exit 1 ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,8 @@ script:
   > body.json
 - echo $(cat body.json)
 - 'TEST_THEME_ID=$(curl -d @body.json -H "Accept: application/json" -H "Content-Type: application/json" https://$SHOPIFY_API_KEY:$SHOPIFY_API_PASSWORD@$SHOPIFY_URL/admin/api/2019-04/themes.json | ./jq -r ''.theme.id'')'
-- echo ${TEST_THEME_ID}
+- echo $TEST_THEME_ID
+- echo $SHOPIFY_URL
 - if [ ${TEST_THEME_ID} == null ] ; then exit 1 ; fi
 - while [ $(curl https://${SHOPIFY_API_KEY}:${SHOPIFY_API_PASSWORD}@${SHOPIFY_URL}/admin/api/2019-04/themes/$TEST_THEME_ID.json | jq -r '.theme.previewable') != 'true' ]; do echo 'Waiting for theme'; sleep 2;
   done


### PR DESCRIPTION
# Pull request for: [PivotalTracker](PIVOTAL_TRACKER_URL)

## Description
This should fix the Theme ID null issue raised here:
https://github.com/pixelcabin/shopify_theme_integration_tests/issues/2
 
As Grunt CLI is a bit flaky at allocating and included lib components, this should force it to install before calling it on the "zip" command down stream. 

## Screenshots / Testing URLs / Theme URLs

To be added

## Additional information (Optional)

This does not effect the circle CI flow. As it forgoes grunt and expects granular build steps.