### PR TITLE
Add Gulp globally, Test ngrok, Add dynamic cypress.json write

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ cache:
 install:
 - npm install
 - npm install -g ngrok
+- npm install -g grunt-cli
 before_script:
 - mkdir public
 - curl -sO http://stedolan.github.io/jq/download/linux64/jq
@@ -19,16 +20,19 @@ script:
 - echo {} > credentials.json
 - grunt zip
 - NGROK_PATH=$(curl 'http://localhost:4040/api/tunnels' | jq -r '.tunnels[0].public_url')/theme.zip
-- echo "{\"theme\":{\"name\":\"Travis Curl Test - $(date +"%D %T %Z")\",\"src\":\"$NGROK_PATH\"}}"
-  > body.json
+- echo "{\"theme\":{\"name\":\"Travis Curl Test - $(date +"%D %T %Z")\",\"src\":\"$NGROK_PATH\"}}" > body.json
 - echo $(cat body.json)
 - 'TEST_THEME_ID=$(curl -d @body.json -H "Accept: application/json" -H "Content-Type:
   application/json" https://${SHOPIFY_API_KEY}:${SHOPIFY_API_PASSWORD}@${SHOPIFY_URL}/admin/api/2019-04/themes.json
   | jq -r ''.theme.id'')'
 - if [ ${TEST_THEME_ID} == null ] ; then exit 1 ; fi
+# Added Sleep to 5, as these are never available before that. 
 - while [ $(curl https://${SHOPIFY_API_KEY}:${SHOPIFY_API_PASSWORD}@${SHOPIFY_URL}/admin/api/2019-04/themes/$TEST_THEME_ID.json
-  | jq -r '.theme.previewable') != 'true' ]; do echo 'Waiting for theme'; sleep 2;
+  | jq -r '.theme.previewable') != 'true' ]; do echo 'Waiting for theme'; sleep 5;
   done
+# dynamically write the cypress.json with the env var SHOPIFY_URL
+- echo "{\"baseUrl\":\"https://${SHOPIFY_URL}\"}" > cypress.json
+- echo $(cat cypress.json)
 - cypress run --env SHOPIFY_URL=${SHOPIFY_URL},SHOPIFY_THEME_ID=$TEST_THEME_ID
 - 'curl -H "Accept: application/json" -X DELETE https://${SHOPIFY_API_KEY}:${SHOPIFY_API_PASSWORD}@${SHOPIFY_URL}/admin/api/2019-04/themes/$TEST_THEME_ID.json'
 addons:
@@ -37,6 +41,9 @@ addons:
     packages:
       # Ubuntu 16+ does not install this dependency by default, so we need to install it ourselves
       - libgconf-2-4
+
+# probably better as a global variables, per branch instead of per config.
+# Comment out below if using a defined env variable through travis.
 env:
   global:
   - SHOPIFY_URL: integration-testing-example.myshopify.com

--- a/README.md
+++ b/README.md
@@ -42,11 +42,12 @@ To start up the Cypress interface, run `cypress open`, and then select one or mo
 ### Integrating Cypress tests with Travis
 This repo has everything set up ready to run Cypress tests on Travis CI. To try this out, first create an account at travis-ci.com, and connect to your Github account or organisation.
 
-For Travis to successfully run the various commands, it will need to have access to some key ENV variables. Some are not sensitive (such as the store url), and can be added to the `.travis.yml` file in the clear. Others will need to be stored securely - these can be added as encrypted values to the `.travis.yml` file, using the [Travis CLI](https://docs.travis-ci.com/user/environment-variables/#encrypting-environment-variables).
+For Travis to successfully run the various commands, it will need to have access to some key ENV variables. Some are not sensitive (such as the store url), and can be added to the `.travis.yml` file in the clear. Others will need to be stored securely - these can be added as encrypted values to the `.travis.yml` file, using the [Travis CLI](https://docs.travis-ci.com/user/environment-variables/#encrypting-environment-variables). These can also be added in the travis GUI, under settings. 
 
-1. In `.travis.yml`, set a value under `env.global.shopify_url` to the store you'll be running the tests against
-1. Using the Travis CLI, run `travis encrypt SHOPIFY_API_KEY=[your api key] --add`
-1. Using the Travis CLI, run `travis encrypt SHOPIFY_API_PASSWORD=[your api password] --add`
+1. In `.travis.yml`, set a value under `env.global.SHOPIFY_URL` to the store you'll be running the tests against ( you can also add this a travis env variable and omit the definition in the travis.yml)
+2. Using the Travis CLI, run `travis encrypt SHOPIFY_API_KEY=[your api key] --add`
+3. Using the Travis CLI, run `travis encrypt SHOPIFY_API_PASSWORD=[your api password] --add`
+
 
 You'll also need an ngrok account (you can use the free plan) - once set up, grab your auth token from [https://dashboard.ngrok.com/auth](https://dashboard.ngrok.com/auth), and add to Travis: `travis encrypt NGROK_AUTH_TOKEN=[your ngrok auth token] --add`
 


### PR DESCRIPTION
Alos adds a cypress.json overwrite for if the SHOPIFY_URL is passed in
from travis.

- Add grunt CLI globally
- Travis dynamically write cypress.json
- Reference usage of the GUI in travis for handling variables.
- leave comments suggesting using env var for SHOPIFY_URL

# Pull request for: [PivotalTracker](PIVOTAL_TRACKER_URL)

## Description

To fix the travis builds on the source repository, checked the configs revised some timings to reduce the calls to an api that is unlikely to be ready. 

- Added grunt cli globally to fix: 
Issue :  https://github.com/pixelcabin/shopify_theme_integration_tests/issues/2

Suggested moving SHOPIFY_URL to travis env vars, and comment to remove or comment out the definition of such in the config. The reasoning behind this is that as env vars are per branch targets can be switched without multiple configs or neededing to edit config code. 

Note: while testing I noticed that ngrok at present fails with no errors, this is fragile.